### PR TITLE
Added install instruction for dev plugin

### DIFF
--- a/index.md
+++ b/index.md
@@ -82,6 +82,10 @@ ibmcloud dev help
 {: codeblock}
 
 The output lists the usage instructions, the current version, and the supported commands.
+If the output is `'dev' is not a registered command`, then install the `dev` plugin:
+```
+ibmcloud plugin install dev -r bluemix
+```
 
 ## Step 3. Configure your environment
 {: #step3-configure-idt-env}


### PR DESCRIPTION
I faced the problem of the 'dev' is not a registered command, after some research I found it and fixed my problem, so, I tough it would be cool  if the solution could  be under the check of the same.