### PR TITLE
docs: Removed `registry`  subdomain in url

### DIFF
--- a/idt/commands.md
+++ b/idt/commands.md
@@ -374,7 +374,7 @@ chart-path: "chart/myapp"
 
 deploy-target: "container"
 
-deploy-image-target: "registry.<IBM Cloud Region>.icr.io/<Container Registry Namespace>/<App-Name>"
+deploy-image-target: "<IBM Cloud Region>.icr.io/<Container Registry Namespace>/<App-Name>"
 
 ibm-cluster: "mycluster"
 ```


### PR DESCRIPTION
# Context

`registry` subdomain of `registry.<region>.icr.io` is no longer used and should be removed .